### PR TITLE
update location to be shown, fix ssh help formatting

### DIFF
--- a/index.md
+++ b/index.md
@@ -97,7 +97,7 @@ This block displays the date and time.
 
 <p id="where">
   <strong>Where:</strong>
-  Wageningen University, building + room to be announced
+  Wageningen University, Forum building, room B0217
 </p>
 
 {% comment %}
@@ -331,5 +331,7 @@ during the workshop.
 <ul>
   <li>Install Shell and Git. Please refer to <a href="https://coderefinery.github.io/installation/shell-and-git/">this page</a> for installation instructions.</li>
   <li>Create a GitLab account. Please refer to <a href="https://gitlab.com/users/sign_up">this page</a> for instructions.</li>
-  <li>Set up an SSH connection to GitLab. First <a href="https://docs.gitlab.com/ee/user/ssh.html#see-if-you-have-an-existing-ssh-key-pair">check if you have an ssh key</a>. Then create an SSH key pair if you don't have one, please refer to <a href="https://docs.gitlab.com/ee/user/ssh.html#generate-an-ssh-key-pair">this page</a> for instructions. Then add the SSH key to your GitLab account following <a href="https://docs.gitlab.com/ee/user/ssh.html#add-an-ssh-key-to-your-gitlab-account">these instructions</a></li>. You can then verify the SSH connection by running `ssh -T git@git.wur.nl` inside your terminal (for example Git Bash). The terminal will ask: 'Are you sure you want to continue connecting'. Respond with 'yes'. If you see 'Welcome to GitLab, username' you are succesfully setup! Otherwise send an email to s.vanderburg@esciencecenter.nl and s.vanrijn@esciencecenter.nl and we will help you with your setup.
+  <li>Set up an SSH connection to GitLab. First <a href="https://docs.gitlab.com/ee/user/ssh.html#see-if-you-have-an-existing-ssh-key-pair">check if you have an ssh key</a>. Then create an SSH key pair if you don't have one, please refer to <a href="https://docs.gitlab.com/ee/user/ssh.html#generate-an-ssh-key-pair">this page</a> for instructions. Then add the SSH key to your GitLab account following <a href="https://docs.gitlab.com/ee/user/ssh.html#add-an-ssh-key-to-your-gitlab-account">these instructions</a>.</li>
+  <li> You can then verify the SSH connection by running `ssh -T git@git.wur.nl` inside your terminal (for example Git Bash). The terminal will ask: 'Are you sure you want to continue connecting'. Respond with 'yes'.</li>
+  <li> If you see 'Welcome to GitLab, username' you are succesfully setup! Otherwise send an email to s.vanderburg@esciencecenter.nl and s.vanrijn@esciencecenter.nl and we will help you with your setup.</li>
 </ul>


### PR DESCRIPTION
- Location was not showing on themain page, explicitly added it there.
- The paragraph on checking the SSH key/connection was formatted oddly, included those instructions in the list-formatting.T